### PR TITLE
provide common-js packages mapping to main requirejs config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ set ( ${PROJECT_NAME}_DEPS
         staticlib_json
         staticlib_utils
         staticlib_tinydir
+        staticlib_unzip
         popt )
         
 staticlib_pkg_check_modules ( ${PROJECT_NAME}_DEPS_PC REQUIRED ${PROJECT_NAME}_DEPS )
@@ -38,6 +39,8 @@ target_include_directories ( ${PROJECT_NAME} BEFORE PRIVATE
 target_link_libraries ( ${PROJECT_NAME} PRIVATE
         wilton_signal
         wilton_core
+        wilton_logging
+        wilton_zip
         ${${PROJECT_NAME}_DEPS_PC_LIBRARIES} )
 
 if ( STATICLIB_TOOLCHAIN MATCHES "windows_.+" )


### PR DESCRIPTION
Wilton uses a [number](https://github.com/wilton-iot/wilton/tree/master/js) of [CommonJS](https://en.wikipedia.org/wiki/CommonJS) packages that usually contain "entry point redirections" in `package.json` ([example](https://github.com/wilton-iot/buffer/blob/6a915790a86d7e748b1d86df1dc4406fb8f317cd/package.json#L53)). RequireJS [supports](http://requirejs.org/docs/api.html#packages) CommonJS packages, but requires a mapping to be provided as a `packages` entry in config. Wilton contains [such mapping](https://github.com/wilton-iot/wilton-requirejs/blob/957c22aa6fb45c5202eaf1cc302adcfa79b65fa5/wilton-packages.json), but it is currently [used only in browser](https://github.com/wilton-iot/examples/blob/8869318176e4e0b6b33d4443b1752e10cf709599/browser/web/main.js#L23) and this [ugly workaround in wilton_loader](https://github.com/wilton-iot/wilton_loader/blob/d926e121d3f86e2af896aacb8b7ebec7fda843cb/src/wilton_loader.cpp#L166) is used instead on server.

With this change packages mapping is loaded on startup and added to `wiltonConfig`.

Workaround in `wilton_loader` can be dropped after this change is merged. Some changes will also be required for JVM init code for Rhino and Nashorn.